### PR TITLE
append to yas-snippet-dirs and only once

### DIFF
--- a/js-react-redux-yasnippets.el
+++ b/js-react-redux-yasnippets.el
@@ -73,7 +73,7 @@
 (defun js-react-redux-yasnippets-initialize ()
   "Initialize js-react-redux-yasnippets with yasnippet."
   (let ((snippets-dir (expand-file-name "snippets" js-react-redux-yasnippets-dir)))
-    (add-to-list 'yas-snippet-dirs snippets-dir nil #'eq)
+    (add-to-list 'yas-snippet-dirs snippets-dir t #'string-equal)
     (yas-load-directory snippets-dir)))
 
 ;;;###autoload


### PR DESCRIPTION
put our directory at the end of the list because first directory
in `yas-snippet-dirs` is treated as a default location for storing
new snippets created with `yas-new-snippet`

this will also allow user to override `js-react-redux-yasnippets` snippets

lastly, we must test for string equality with `string-equal `otherwise
`snippets-dir `will be added to the `yas-snippet-dirs` everytime
this function is executed